### PR TITLE
Update __init__.py to show correct version of release

### DIFF
--- a/src/dtumathtools/__init__.py
+++ b/src/dtumathtools/__init__.py
@@ -3,6 +3,6 @@ from . import dtutools
 
 __author__ = "Christian Mikkelstrup and Hans Henrik Hermansen"
 __license__ = "BSD-3-Clause"
-__version__ = "2024.1.0"
+__version__ = "2024.2.0"
 
 __all__ = ["dtuplot", "dtutools"]


### PR DESCRIPTION
When running

```{python}
import dtumathtools
print(dtumathtools.__version__)
```
This prints "2024.1.0" when the installed conda version is 2024.2.0.

This pull request changes the displayed version to correct conda version.